### PR TITLE
remove version tags from requirements, request newer Python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.23.2
-matplotlib==3.5.3
-imageio==2.21.2
-pandas==1.4.4
-nose==1.3.7
+numpy
+matplotlib
+imageio
+pandas
+nose
 jupyter-offlinenotebook
 #jupyterlab-git  # Disabling jupyterlab-git for now as it hangs indefinitely


### PR DESCRIPTION
so binder’s default python version 3.7 can resolve dependencies, and the Python version in the notebooks is the same as on our local computers.